### PR TITLE
Move expansion of `Charms.Defm.if` to `Kernel.if`

### DIFF
--- a/bench/enif_merge_sort.ex
+++ b/bench/enif_merge_sort.ex
@@ -40,7 +40,7 @@ defmodule ENIFMergeSort do
       left_term = Pointer.load(Term.t(), Pointer.element_ptr(Term.t(), left_temp, i))
       right_term = Pointer.load(Term.t(), Pointer.element_ptr(Term.t(), right_temp, j))
 
-      struct_if(enif_compare(left_term, right_term) <= 0) do
+      if(enif_compare(left_term, right_term) <= 0) do
         Pointer.store(
           Pointer.load(Term.t(), Pointer.element_ptr(Term.t(), left_temp, i)),
           Pointer.element_ptr(Term.t(), arr, k)
@@ -89,7 +89,7 @@ defmodule ENIFMergeSort do
   end
 
   defm do_sort(arr :: Pointer.t(), l :: i32(), r :: i32()) do
-    struct_if(l < r) do
+    if(l < r) do
       two_const = op arith.constant(value: Attribute.integer(i32(), 2)) :: i32()
       two = result_at(two_const, 0)
       m = op arith.divsi(l + r, two) :: i32()

--- a/bench/enif_quick_sort.ex
+++ b/bench/enif_quick_sort.ex
@@ -22,7 +22,7 @@ defmodule ENIFQuickSort do
     start = Pointer.element_ptr(Term.t(), arr, low)
 
     for_loop {element, j} <- {Term.t(), start, high - low} do
-      struct_if(enif_compare(element, pivot) < 0) do
+      if(enif_compare(element, pivot) < 0) do
         i = Pointer.load(i32(), i_ptr) + 1
         Pointer.store(i, i_ptr)
         j = value index.casts(j) :: i32()
@@ -40,7 +40,7 @@ defmodule ENIFQuickSort do
   end
 
   defm do_sort(arr :: Pointer.t(), low :: i32(), high :: i32()) do
-    struct_if(low < high) do
+    if(low < high) do
       pi = call partition(arr, low, high) :: i32()
       do_sort(arr, low, pi - 1)
       do_sort(arr, pi + 1, high)

--- a/bench/enif_tim_sort.ex
+++ b/bench/enif_tim_sort.ex
@@ -66,8 +66,8 @@ defmodule ENIFTimSort do
         right = op arith.minsi(left + 2 * size - 1, n - 1) :: i32()
         right = result_at(right, 0)
 
-        struct_if(mid < right) do
-          call ENIFMergeSort.merge(arr, left, mid, right) :: []
+        if(mid < right) do
+          call ENIFMergeSort.merge(arr, left, mid, right)
         end
 
         Pointer.store(left + 2 * size, left_ptr)

--- a/lib/charms/defm.ex
+++ b/lib/charms/defm.ex
@@ -47,11 +47,6 @@ defmodule Charms.Defm do
   defmacro cond_br(_condition, _clauses), do: :implemented_in_expander
 
   @doc """
-  `if` expression requires identical types for both branches
-  """
-  defmacro struct_if(_condition, _clauses), do: :implemented_in_expander
-
-  @doc """
   define a function that can be JIT compiled
 
   ## Differences from `Beaver.>>>/2` op expressions

--- a/lib/charms/defm/expander.ex
+++ b/lib/charms/defm/expander.ex
@@ -570,6 +570,7 @@ defmodule Charms.Defm.Expander do
     Module.concat(mod, func)
   end
 
+  # Expands a nil clause body in an if statement, yielding no value.
   defp expand_if_clause_body(nil, state, _env) do
     mlir ctx: state.mlir.ctx, block: state.mlir.blk do
       SCF.yield() >>> []
@@ -577,6 +578,7 @@ defmodule Charms.Defm.Expander do
     end
   end
 
+  # Expands a non-nil clause body in an if statement, yielding the last evaluated value.
   defp expand_if_clause_body(clause_body, state, env) do
     mlir ctx: state.mlir.ctx, block: state.mlir.blk do
       {ret, _, _} = expand(clause_body, state, env)
@@ -734,6 +736,7 @@ defmodule Charms.Defm.Expander do
     {v, state, env}
   end
 
+  # Expands an `if` expression, handling both true and false clause bodies.
   defp expand_macro(_meta, Kernel, :if, [condition, clauses], _callback, state, env) do
     true_body = Keyword.fetch!(clauses, :do)
     false_body = clauses[:else]

--- a/lib/charms/prelude.ex
+++ b/lib/charms/prelude.ex
@@ -8,8 +8,7 @@ defmodule Charms.Prelude do
     @enif_functions ++ [:result_at] ++ @binary_ops
   end
 
-  @doc false
-  def constant_of_same_type(i, v, opts) do
+  defp constant_of_same_type(i, v, opts) do
     mlir ctx: opts[:ctx], block: opts[:block] do
       t = MLIR.CAPI.mlirValueGetType(v)
       Arith.constant(value: Attribute.integer(t, i)) >>> t

--- a/lib/charms/prelude.ex
+++ b/lib/charms/prelude.ex
@@ -8,7 +8,8 @@ defmodule Charms.Prelude do
     @enif_functions ++ [:result_at] ++ @binary_ops
   end
 
-  defp constant_of_same_type(i, v, opts) do
+  @doc false
+  def constant_of_same_type(i, v, opts) do
     mlir ctx: opts[:ctx], block: opts[:block] do
       t = MLIR.CAPI.mlirValueGetType(v)
       Arith.constant(value: Attribute.integer(t, i)) >>> t

--- a/test/if_test.exs
+++ b/test/if_test.exs
@@ -1,0 +1,32 @@
+defmodule IfTest do
+  use ExUnit.Case
+
+  test "if with value" do
+    defmodule GetIntIf do
+      use Charms
+      alias Charms.{Pointer, Term}
+
+      defm get(env, i) :: Term.t() do
+        zero = arith.constant(value: Attribute.integer(i32(), 0))
+        one = arith.constant(value: Attribute.integer(i32(), 1))
+        i_ptr = Pointer.allocate(i32())
+        enif_get_int(env, i, i_ptr)
+        i = Pointer.load(i32(), i_ptr)
+
+        ret =
+          if(i > 0) do
+            one
+          else
+            zero
+          end
+
+        ret = enif_make_int(env, ret)
+        func.return(ret)
+      end
+    end
+    |> Charms.JIT.init()
+
+    assert GetIntIf.get(100) == 1
+    assert GetIntIf.get(-100) == 0
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced tests for the `GetIntIf` module, ensuring correct functionality of the conditional logic based on integer inputs.

- **Bug Fixes**
  - Enhanced readability and maintainability by standardizing control flow structures from `struct_if` to conventional `if` statements across multiple sorting algorithms.

- **Documentation**
  - Updated the visibility of the `constant_of_same_type` function to public, although it is marked as not part of the public API.

- **Chores**
  - Removed unnecessary macros and streamlined macro expansion logic to align with Elixir best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->