### PR TITLE
Remove calling `Enum.to_list/1`

### DIFF
--- a/lib/charms/jit.ex
+++ b/lib/charms/jit.ex
@@ -24,7 +24,7 @@ defmodule Charms.JIT do
   end
 
   defp clone_func_impl(to, from) do
-    ops = MLIR.Module.body(from) |> Beaver.Walker.operations() |> Enum.to_list()
+    ops = MLIR.Module.body(from) |> Beaver.Walker.operations()
     s_table = to |> MLIR.Operation.from_module() |> mlirSymbolTableCreate()
 
     for op <- ops, MLIR.Operation.name(op) == "func.func" do

--- a/lib/charms/simd.ex
+++ b/lib/charms/simd.ex
@@ -6,9 +6,9 @@ defmodule Charms.SIMD do
   def handle_intrinsic(:new, [type, width], opts) do
     fn literal_values ->
       mlir ctx: opts[:ctx], block: opts[:block] do
-        values = Enum.map(literal_values, &Attribute.integer(type, &1)) |> Enum.to_list()
+        values = Enum.map(literal_values, &Attribute.integer(type, &1))
 
-        if length(values) != width do
+        if Enum.count(values) != width do
           raise ArgumentError, "expected #{width} values, got #{length(values)}"
         end
 

--- a/test/vec_add_test.exs
+++ b/test/vec_add_test.exs
@@ -4,7 +4,7 @@ defmodule VecAddTest do
   test "vec add" do
     {:ok, _} = Charms.JIT.init(AddTwoIntVec)
     a = 1..8 |> Enum.to_list()
-    b = List.duplicate(1, 8) |> Enum.to_list()
+    b = List.duplicate(1, 8)
     assert AddTwoIntVec.add(a, b, :err) == Enum.to_list(2..9)
   end
 


### PR DESCRIPTION
After bug in Beaver was fixed, it should be no problem calling Enum functions on walker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Enhanced efficiency in handling operations by removing unnecessary list conversion in the `Charms.JIT` module.
	- Updated method for determining the length of lists in the `Charms.SIMD` module for improved readability and consistency.

- **Code Simplification**
	- Streamlined test case for vector addition by removing redundant operations in the `VecAddTest` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->