### PR TITLE
Put expansion frame in `__STACKTRACE__`

### DIFF
--- a/test/expander_test.exs
+++ b/test/expander_test.exs
@@ -150,7 +150,14 @@ defmodule POCTest do
     test "imports modules" do
       # The macro discards the content, so if the module is imported,
       # the macro is invoked and contents are discarded
-      assert catch_error(remotes("discard_import(foo())")) == :function_clause
+      assert %FunctionClauseError{
+               module: Beaver.MLIR.Operation.Changeset,
+               function: :add_argument,
+               arity: 2,
+               kind: nil,
+               args: nil,
+               clauses: nil
+             } = catch_error(remotes("discard_import(foo())"))
 
       # assert locals("discard_import(foo())") == [discard_import: 1, foo: 0]
       assert locals("import POCTest; discard_import(foo())") == []

--- a/test/stacktrace_test.exs
+++ b/test/stacktrace_test.exs
@@ -1,0 +1,34 @@
+defmodule StackTraceTest do
+  use ExUnit.Case
+
+  test "insert frame into stacktrace" do
+    res =
+      try do
+        defmodule AddTwoIntVecVariableSize do
+          use Charms
+          alias Charms.{SIMD, Term, Pointer}
+
+          defm add(env, a, b, error) :: Term.t() do
+            size = enif_list_length(env, a)
+
+            v1 =
+              call load_list(env, a, size) ::
+                     SIMD.t(i32(), :variable)
+          end
+        end
+      rescue
+        _e ->
+          assert [
+                   _,
+                   _,
+                   _,
+                   {Charms.SIMD, :t, 2, [file: ~c"test/stacktrace_test.exs", line: 16]},
+                   {Charms.Defm, :call, 1, [file: ~c"test/stacktrace_test.exs", line: 15]} | _
+                 ] = __STACKTRACE__
+
+          :ok
+      end
+
+    assert res == :ok
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and stack trace management in the Charms.Defm.Expander module.
	- Improved context preservation during error reporting for better debugging.

- **Bug Fixes**
	- Updated error handling in tests to ensure more specific error assertions.

- **Tests**
	- Introduced a new test module to validate stack trace functionality and error handling in variable-sized integer vector addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->