### PR TITLE
Remove parentheses in if expression

### DIFF
--- a/bench/enif_merge_sort.ex
+++ b/bench/enif_merge_sort.ex
@@ -40,7 +40,7 @@ defmodule ENIFMergeSort do
       left_term = Pointer.load(Term.t(), Pointer.element_ptr(Term.t(), left_temp, i))
       right_term = Pointer.load(Term.t(), Pointer.element_ptr(Term.t(), right_temp, j))
 
-      if(enif_compare(left_term, right_term) <= 0) do
+      if enif_compare(left_term, right_term) <= 0 do
         Pointer.store(
           Pointer.load(Term.t(), Pointer.element_ptr(Term.t(), left_temp, i)),
           Pointer.element_ptr(Term.t(), arr, k)
@@ -89,7 +89,7 @@ defmodule ENIFMergeSort do
   end
 
   defm do_sort(arr :: Pointer.t(), l :: i32(), r :: i32()) do
-    if(l < r) do
+    if l < r do
       two_const = op arith.constant(value: Attribute.integer(i32(), 2)) :: i32()
       two = result_at(two_const, 0)
       m = op arith.divsi(l + r, two) :: i32()

--- a/bench/enif_quick_sort.ex
+++ b/bench/enif_quick_sort.ex
@@ -22,7 +22,7 @@ defmodule ENIFQuickSort do
     start = Pointer.element_ptr(Term.t(), arr, low)
 
     for_loop {element, j} <- {Term.t(), start, high - low} do
-      if(enif_compare(element, pivot) < 0) do
+      if enif_compare(element, pivot) < 0 do
         i = Pointer.load(i32(), i_ptr) + 1
         Pointer.store(i, i_ptr)
         j = value index.casts(j) :: i32()
@@ -40,7 +40,7 @@ defmodule ENIFQuickSort do
   end
 
   defm do_sort(arr :: Pointer.t(), low :: i32(), high :: i32()) do
-    if(low < high) do
+    if low < high do
       pi = call partition(arr, low, high) :: i32()
       do_sort(arr, low, pi - 1)
       do_sort(arr, pi + 1, high)

--- a/bench/enif_tim_sort.ex
+++ b/bench/enif_tim_sort.ex
@@ -66,7 +66,7 @@ defmodule ENIFTimSort do
         right = op arith.minsi(left + 2 * size - 1, n - 1) :: i32()
         right = result_at(right, 0)
 
-        if(mid < right) do
+        if mid < right do
           call ENIFMergeSort.merge(arr, left, mid, right)
         end
 

--- a/test/if_test.exs
+++ b/test/if_test.exs
@@ -14,7 +14,7 @@ defmodule IfTest do
         i = Pointer.load(i32(), i_ptr)
 
         ret =
-          if(i > 0) do
+          if i > 0 do
             one
           else
             zero


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved readability by removing parentheses from conditional statements in the sorting modules and tests, adhering to a more conventional syntax.
	- Streamlined syntax in `ENIFMergeSort`, `ENIFQuickSort`, `ENIFTimSort`, and `IfTest` modules without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->