### PR TITLE
Macro `const/1` as syntax sugar to create constant op

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,7 +2,8 @@
 locals_without_parens = [
   op: 1,
   value: 1,
-  call: 1
+  call: 1,
+  const: 1
 ]
 
 [

--- a/bench/enif_merge_sort.ex
+++ b/bench/enif_merge_sort.ex
@@ -26,8 +26,7 @@ defmodule ENIFMergeSort do
     j_ptr = Pointer.allocate(i32())
     k_ptr = Pointer.allocate(i32())
 
-    zero_const = op arith.constant(value: Attribute.integer(i32(), 0)) :: i32()
-    zero = result_at(zero_const, 0)
+    zero = const 0 :: i32()
     Pointer.store(zero, i_ptr)
     Pointer.store(zero, j_ptr)
     Pointer.store(l, k_ptr)
@@ -90,8 +89,7 @@ defmodule ENIFMergeSort do
 
   defm do_sort(arr :: Pointer.t(), l :: i32(), r :: i32()) do
     if l < r do
-      two_const = op arith.constant(value: Attribute.integer(i32(), 2)) :: i32()
-      two = result_at(two_const, 0)
+      two = const 2 :: i32()
       m = op arith.divsi(l + r, two) :: i32()
       m = result_at(m, 0)
 
@@ -112,8 +110,7 @@ defmodule ENIFMergeSort do
       len = Pointer.load(i32(), len_ptr)
       arr = Pointer.allocate(Term.t(), len)
       call ENIFTimSort.copy_terms(env, movable_list_ptr, arr) :: []
-      zero_const = op arith.constant(value: Attribute.integer(i32(), 0)) :: i32()
-      zero = result_at(zero_const, 0)
+      zero = const 0 :: i32()
       call do_sort(arr, zero, len - 1) :: []
       ret = enif_make_list_from_array(env, arr, len)
       op func.return(ret) :: []

--- a/bench/enif_quick_sort.ex
+++ b/bench/enif_quick_sort.ex
@@ -51,8 +51,7 @@ defmodule ENIFQuickSort do
 
   defm copy_terms(env :: Env.t(), movable_list_ptr :: Pointer.t(), arr :: Pointer.t()) do
     head = Pointer.allocate(Term.t())
-    zero_const = op arith.constant(value: Attribute.integer(i32(), 0)) :: i32()
-    zero = result_at(zero_const, 0)
+    zero = const 0 :: i32()
     i_ptr = Pointer.allocate(i32())
     Pointer.store(zero, i_ptr)
 
@@ -83,8 +82,7 @@ defmodule ENIFQuickSort do
       len = Pointer.load(i32(), len_ptr)
       arr = Pointer.allocate(Term.t(), len)
       copy_terms(env, movable_list_ptr, arr)
-      zero_const = op arith.constant(value: Attribute.integer(i32(), 0)) :: i32()
-      zero = result_at(zero_const, 0)
+      zero = const 0 :: i32()
       call do_sort(arr, zero, len - 1)
       ret = enif_make_list_from_array(env, arr, len)
       func.return(ret)

--- a/bench/enif_tim_sort.ex
+++ b/bench/enif_tim_sort.ex
@@ -37,11 +37,9 @@ defmodule ENIFTimSort do
   end
 
   defm tim_sort(arr :: Pointer.t(), n :: i32()) do
-    run_const = op arith.constant(value: Attribute.integer(i32(), 32)) :: i32()
-    run = result_at(run_const, 0)
+    run = const 32 :: i32()
     i_ptr = Pointer.allocate(i32())
-    zero_const = op arith.constant(value: Attribute.integer(i32(), 0)) :: i32()
-    zero = result_at(zero_const, 0)
+    zero = const 0 :: i32()
     Pointer.store(zero, i_ptr)
 
     while_loop(Pointer.load(i32(), i_ptr) < n) do
@@ -81,8 +79,7 @@ defmodule ENIFTimSort do
 
   defm copy_terms(env :: Env.t(), movable_list_ptr :: Pointer.t(), arr :: Pointer.t()) do
     head = Pointer.allocate(Term.t())
-    zero_const = op arith.constant(value: Attribute.integer(i32(), 0)) :: i32()
-    zero = result_at(zero_const, 0)
+    zero = const 0 :: i32()
     i_ptr = Pointer.allocate(i32())
     Pointer.store(zero, i_ptr)
 

--- a/bench/vec_add_int_list.ex
+++ b/bench/vec_add_int_list.ex
@@ -23,7 +23,7 @@ defmodule AddTwoIntVec do
     v1 = call load_list(env, a) :: SIMD.t(i32(), 8)
     v2 = call load_list(env, b) :: SIMD.t(i32(), 8)
     v = arith.addi(v1, v2)
-    start = arith.constant(value: Attribute.integer(i32(), 0))
+    start = const 0 :: i32()
 
     ret =
       enif_make_list8(

--- a/bench/vec_add_int_list.ex
+++ b/bench/vec_add_int_list.ex
@@ -4,6 +4,7 @@ defmodule AddTwoIntVec do
 
   defm load_list(env, l :: Term.t()) :: SIMD.t(i32(), 8) do
     i_ptr = Pointer.allocate(i32())
+    # TODO: remove the const here, when pointer's type can be inferred
     Pointer.store(const(0 :: i32()), i_ptr)
     init = SIMD.new(i32(), 8).(0, 0, 0, 0, 0, 0, 0, 0)
 

--- a/bench/vec_add_int_list.ex
+++ b/bench/vec_add_int_list.ex
@@ -4,7 +4,7 @@ defmodule AddTwoIntVec do
 
   defm load_list(env, l :: Term.t()) :: SIMD.t(i32(), 8) do
     i_ptr = Pointer.allocate(i32())
-    Pointer.store(arith.constant(value: Attribute.integer(i32(), 0)), i_ptr)
+    Pointer.store(const(0 :: i32()), i_ptr)
     init = SIMD.new(i32(), 8).(0, 0, 0, 0, 0, 0, 0, 0)
 
     Enum.reduce(l, init, fn x, acc ->

--- a/lib/charms/defm.ex
+++ b/lib/charms/defm.ex
@@ -22,6 +22,11 @@ defmodule Charms.Defm do
   defmacro value(_expr), do: :implemented_in_expander
 
   @doc """
+  syntax sugar to create an MLIR value from an Elixir value
+  """
+  defmacro const(_), do: :implemented_in_expander
+
+  @doc """
   call a local function with return
   """
   defmacro call({:"::", _, [_call, _types]}), do: :implemented_in_expander

--- a/lib/charms/defm/expander.ex
+++ b/lib/charms/defm/expander.ex
@@ -1006,16 +1006,15 @@ defmodule Charms.Defm.Expander do
     {args, state, env} = expand_list(args, state, env)
 
     if module in [MLIR.Type] do
-      {apply(
-         module,
-         fun,
-         args ++
-           if fun in [:unranked_tensor] do
-             []
-           else
-             [[ctx: state.mlir.ctx]]
-           end
-       ), state, env}
+      args =
+        args ++
+          if fun in [:unranked_tensor, :complex, :vector] do
+            []
+          else
+            [[ctx: state.mlir.ctx]]
+          end
+
+      {apply(module, fun, args), state, env}
     else
       {{{:., meta, [module, fun]}, meta, args}, state, env}
     end

--- a/lib/charms/defm/expander.ex
+++ b/lib/charms/defm/expander.ex
@@ -1006,15 +1006,12 @@ defmodule Charms.Defm.Expander do
     {args, state, env} = expand_list(args, state, env)
 
     if module in [MLIR.Type] do
-      args =
-        args ++
-          if fun in [:unranked_tensor, :complex, :vector] do
-            []
-          else
-            [[ctx: state.mlir.ctx]]
-          end
-
-      {apply(module, fun, args), state, env}
+      if fun in [:unranked_tensor, :complex, :vector] do
+        args
+      else
+        args ++ [[ctx: state.mlir.ctx]]
+      end
+      |> then(&{apply(module, fun, &1), state, env})
     else
       {{{:., meta, [module, fun]}, meta, args}, state, env}
     end

--- a/test/const_test.exs
+++ b/test/const_test.exs
@@ -1,0 +1,19 @@
+defmodule ConstTest do
+  use ExUnit.Case, async: true
+
+  test "const with unsupported type" do
+    assert_raise ArgumentError, "Unsupported type for const macro: tensor<*xf64>", fn ->
+      defmodule GetIntIf do
+        use Charms
+        alias Charms.{Pointer, Term}
+
+        defm get(env, i) :: Term.t() do
+          zero = const 0 :: i32()
+          one = const 1.0 :: f64()
+          one = const 1.0 :: unranked_tensor(f64())
+        end
+      end
+      |> Charms.JIT.init()
+    end
+  end
+end

--- a/test/if_test.exs
+++ b/test/if_test.exs
@@ -7,9 +7,8 @@ defmodule IfTest do
       alias Charms.{Pointer, Term}
 
       defm get(env, i) :: Term.t() do
-        zero = const 1 :: i32()
-        zero = arith.constant(value: Attribute.integer(i32(), 0))
-        one = arith.constant(value: Attribute.integer(i32(), 1))
+        zero = const 0 :: i32()
+        one = const 1 :: i32()
         i_ptr = Pointer.allocate(i32())
         enif_get_int(env, i, i_ptr)
         i = Pointer.load(i32(), i_ptr)

--- a/test/if_test.exs
+++ b/test/if_test.exs
@@ -7,6 +7,7 @@ defmodule IfTest do
       alias Charms.{Pointer, Term}
 
       defm get(env, i) :: Term.t() do
+        zero = const 1 :: i32()
         zero = arith.constant(value: Attribute.integer(i32(), 0))
         one = arith.constant(value: Attribute.integer(i32(), 1))
         i_ptr = Pointer.allocate(i32())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `const` macro for simplified constant creation in the `Charms.Defm` module.
- **Improvements**
	- Simplified constant initialization across multiple modules, enhancing code clarity and performance.
- **Bug Fixes**
	- Resolved complexities in constant handling, ensuring smoother functionality in sorting and list operations.
- **Tests**
	- Added a test module to verify the behavior of the `const` macro with unsupported types, ensuring proper error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->