### PR TITLE
Expand `:||` and `:!`

### DIFF
--- a/lib/charms/defm/expander.ex
+++ b/lib/charms/defm/expander.ex
@@ -1052,16 +1052,17 @@ defmodule Charms.Defm.Expander do
     v =
       mlir ctx: state.mlir.ctx, block: state.mlir.blk do
         cond_type = MLIR.Value.type(condition)
-
+        bool_type = Type.i1(ctx: state.mlir.ctx)
         # Ensure the condition is a i1, if not compare it to 0
         condition =
-          if MLIR.equal?(cond_type, Type.i1(ctx: state.mlir.ctx)) do
+          if MLIR.equal?(cond_type, bool_type) do
             condition
           else
             zero =
               Arith.constant(value: Attribute.integer(cond_type, 0), loc: loc) >>> cond_type
 
-            Arith.cmpi(condition, zero, predicate: Arith.cmp_i_predicate(:sgt)) >>> Type.i1()
+            Arith.cmpi(condition, zero, predicate: Arith.cmp_i_predicate(:sgt), loc: loc) >>>
+              Type.i1()
           end
 
         b =

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -3,8 +3,8 @@ defmodule AddTwoInt do
   alias Charms.{Pointer, Term}
 
   defm add_or_error(env, a, b, error) :: Term.t() do
-    ptr_a = Pointer.allocate(i64())
-    ptr_b = Pointer.allocate(i64())
+    ptr_a = Pointer.allocate(i32())
+    ptr_b = Pointer.allocate(i32())
 
     arg_err =
       block do
@@ -12,11 +12,11 @@ defmodule AddTwoInt do
       end
 
     cond_br enif_get_int64(env, a, ptr_a) != 0 do
-      cond_br 0 != enif_get_int64(env, b, ptr_b) do
-        a = Pointer.load(i64(), ptr_a)
-        b = Pointer.load(i64(), ptr_b)
-        sum = value llvm.add(a, b) :: i64()
-        term = enif_make_int64(env, sum)
+      cond_br 0 != enif_get_int(env, b, ptr_b) do
+        a = Pointer.load(i32(), ptr_a)
+        b = Pointer.load(i32(), ptr_b)
+        sum = value llvm.add(a, b) :: i32()
+        term = enif_make_int(env, sum)
         func.return(term)
       else
         ^arg_err

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -1,3 +1,58 @@
+defmodule AddTwoInt do
+  use Charms, init: false
+  alias Charms.{Pointer, Term}
+
+  defm add_or_error(env, a, b, error) :: Term.t() do
+    ptr_a = Pointer.allocate(i64())
+    ptr_b = Pointer.allocate(i64())
+
+    arg_err =
+      block do
+        func.return(error)
+      end
+
+    cond_br enif_get_int64(env, a, ptr_a) != 0 do
+      cond_br 0 != enif_get_int64(env, b, ptr_b) do
+        a = Pointer.load(i64(), ptr_a)
+        b = Pointer.load(i64(), ptr_b)
+        sum = value llvm.add(a, b) :: i64()
+        term = enif_make_int64(env, sum)
+        func.return(term)
+      else
+        ^arg_err
+      end
+    else
+      ^arg_err
+    end
+  end
+
+  defm add0(env, a, b) :: Term.t() do
+    ptr_a = Pointer.allocate(i32())
+    ptr_b = Pointer.allocate(i32())
+
+    if enif_get_int(env, a, ptr_a) <= 0 || enif_get_int(env, b, ptr_b) <= 0 do
+      enif_make_badarg(env)
+    else
+      a = Pointer.load(i32(), ptr_a)
+      b = Pointer.load(i32(), ptr_b)
+      enif_make_int(env, a + b)
+    end
+  end
+
+  defm add(env, a, b) :: Term.t() do
+    ptr_a = Pointer.allocate(i32())
+    ptr_b = Pointer.allocate(i32())
+
+    if !enif_get_int(env, a, ptr_a) || !enif_get_int(env, b, ptr_b) do
+      enif_make_badarg(env)
+    else
+      a = Pointer.load(i32(), ptr_a)
+      b = Pointer.load(i32(), ptr_b)
+      enif_make_int(env, a + b)
+    end
+  end
+end
+
 defmodule DefmTest do
   use ExUnit.Case, async: true
 
@@ -6,28 +61,32 @@ defmodule DefmTest do
   end
 
   test "invalid return of absent alias" do
-    assert_raise CompileError, "test/defm_test.exs:13: invalid return type", fn ->
-      defmodule InvalidRet do
-        use Charms
+    assert_raise CompileError,
+                 "test/defm_test.exs:#{__ENV__.line + 5}: invalid return type",
+                 fn ->
+                   defmodule InvalidRet do
+                     use Charms
 
-        defm my_function(env, arg1, arg2) :: Invalid.t() do
-          func.return(arg2)
-        end
-      end
-    end
+                     defm my_function(env, arg1, arg2) :: Invalid.t() do
+                       func.return(arg2)
+                     end
+                   end
+                 end
   end
 
   test "invalid arg of absent alias" do
-    assert_raise CompileError, "test/defm_test.exs:26: invalid argument type #2", fn ->
-      defmodule InvalidRet do
-        use Charms
-        alias Charms.Term
+    assert_raise CompileError,
+                 "test/defm_test.exs:#{__ENV__.line + 6}: invalid argument type #2",
+                 fn ->
+                   defmodule InvalidRet do
+                     use Charms
+                     alias Charms.Term
 
-        defm my_function(env, arg1 :: Pointer.t(), arg2) :: Term.t() do
-          func.return(arg2)
-        end
-      end
-    end
+                     defm my_function(env, arg1 :: Pointer.t(), arg2) :: Term.t() do
+                       func.return(arg2)
+                     end
+                   end
+                 end
   end
 
   test "only env defm is exported" do
@@ -39,41 +98,16 @@ defmodule DefmTest do
   end
 
   test "add two integers" do
-    defmodule AddTwoInt do
-      use Charms, init: false
-      alias Charms.{Pointer, Term}
-
-      defm add(env, a, b, error) :: Term.t() do
-        ptr_a = Pointer.allocate(i64())
-        ptr_b = Pointer.allocate(i64())
-
-        arg_err =
-          block do
-            func.return(error)
-          end
-
-        cond_br enif_get_int64(env, a, ptr_a) != 0 do
-          cond_br 0 != enif_get_int64(env, b, ptr_b) do
-            a = Pointer.load(i64(), ptr_a)
-            b = Pointer.load(i64(), ptr_b)
-            sum = value llvm.add(a, b) :: i64()
-            term = enif_make_int64(env, sum)
-            func.return(term)
-          else
-            ^arg_err
-          end
-        else
-          ^arg_err
-        end
-      end
-    end
-
     assert {:ok, %Charms.JIT{}} = Charms.JIT.init(AddTwoInt, name: :add_int)
     assert {:cached, %Charms.JIT{}} = Charms.JIT.init(AddTwoInt, name: :add_int)
     engine = Charms.JIT.engine(:add_int)
     assert String.starts_with?(AddTwoInt.__ir__(), "ML\xefR")
-    assert AddTwoInt.add(1, 2, :arg_err).(engine) == 3
-    assert AddTwoInt.add(1, "", :arg_err).(engine) == :arg_err
+    assert AddTwoInt.add(1, 2).(engine) == 3
+    assert_raise ArgumentError, fn -> AddTwoInt.add(1, "2").(engine) end
+    assert AddTwoInt.add0(1, 2).(engine) == 3
+    assert_raise ArgumentError, fn -> AddTwoInt.add0(1, "2").(engine) end
+    assert AddTwoInt.add_or_error(1, 2, :arg_err).(engine) == 3
+    assert AddTwoInt.add_or_error(1, "", :arg_err).(engine) == :arg_err
     assert :ok = Charms.JIT.destroy(:add_int)
   end
 
@@ -109,8 +143,10 @@ defmodule DefmTest do
     end
 
     test "undefined remote function" do
+      line = __ENV__.line
+
       assert_raise CompileError,
-                   "test/defm_test.exs:119: Failed to expand macro Elixir.DifferentCalls.something/1: test/defm_test.exs:119: function something not found in module DifferentCalls",
+                   ~r"Failed to expand macro Elixir.DifferentCalls.something/1.+function something not found in module DifferentCalls",
                    fn ->
                      defmodule Undefined do
                        use Charms
@@ -124,7 +160,7 @@ defmodule DefmTest do
 
     test "wrong return type remote function" do
       assert_raise CompileError,
-                   "test/defm_test.exs:133: mismatch type in invocation: f32 vs. i64",
+                   ~r"mismatch type in invocation: f32 vs. i64",
                    fn ->
                      defmodule WrongReturnType do
                        use Charms

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -2,7 +2,7 @@ defmodule AddTwoInt do
   use Charms, init: false
   alias Charms.{Pointer, Term}
 
-  defm add_or_error(env, a, b, error) :: Term.t() do
+  defm add_or_error_with_cond_br(env, a, b, error) :: Term.t() do
     ptr_a = Pointer.allocate(i32())
     ptr_b = Pointer.allocate(i32())
 
@@ -11,7 +11,7 @@ defmodule AddTwoInt do
         func.return(error)
       end
 
-    cond_br enif_get_int64(env, a, ptr_a) != 0 do
+    cond_br enif_get_int(env, a, ptr_a) != 0 do
       cond_br 0 != enif_get_int(env, b, ptr_b) do
         a = Pointer.load(i32(), ptr_a)
         b = Pointer.load(i32(), ptr_b)
@@ -23,19 +23,6 @@ defmodule AddTwoInt do
       end
     else
       ^arg_err
-    end
-  end
-
-  defm add0(env, a, b) :: Term.t() do
-    ptr_a = Pointer.allocate(i32())
-    ptr_b = Pointer.allocate(i32())
-
-    if enif_get_int(env, a, ptr_a) <= 0 || enif_get_int(env, b, ptr_b) <= 0 do
-      enif_make_badarg(env)
-    else
-      a = Pointer.load(i32(), ptr_a)
-      b = Pointer.load(i32(), ptr_b)
-      enif_make_int(env, a + b)
     end
   end
 
@@ -104,10 +91,8 @@ defmodule DefmTest do
     assert String.starts_with?(AddTwoInt.__ir__(), "ML\xefR")
     assert AddTwoInt.add(1, 2).(engine) == 3
     assert_raise ArgumentError, fn -> AddTwoInt.add(1, "2").(engine) end
-    assert AddTwoInt.add0(1, 2).(engine) == 3
-    assert_raise ArgumentError, fn -> AddTwoInt.add0(1, "2").(engine) end
-    assert AddTwoInt.add_or_error(1, 2, :arg_err).(engine) == 3
-    assert AddTwoInt.add_or_error(1, "", :arg_err).(engine) == :arg_err
+    assert AddTwoInt.add_or_error_with_cond_br(1, 2, :arg_err).(engine) == 3
+    assert AddTwoInt.add_or_error_with_cond_br(1, "", :arg_err).(engine) == :arg_err
     assert :ok = Charms.JIT.destroy(:add_int)
   end
 


### PR DESCRIPTION
- expand `:||` and `:!`
- cast condition to `i1` in `if`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for the logical OR operator `:||` in binary operations.
	- Added new functions for integer addition with improved error handling: `add_or_error_with_cond_br` and `add`.
	- Enhanced handling of negation with the new `expand_macro` function for the `Kernel.!` operator.

- **Bug Fixes**
	- Enhanced type safety in binary operations and conditional expressions to prevent type mismatches.

- **Documentation**
	- Updated tests to reflect new function signatures and improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->