### PR TITLE
Use `__IR__` in `defintrinsic`

### DIFF
--- a/lib/charms/env.ex
+++ b/lib/charms/env.ex
@@ -5,7 +5,8 @@ defmodule Charms.Env do
   use Charms.Intrinsic
   alias Charms.Intrinsic.Opts
 
-  defintrinsic t(), %Opts{ctx: ctx} do
+  defintrinsic t() do
+    %Opts{ctx: ctx} = __IR__
     Beaver.ENIF.Type.env(ctx: ctx)
   end
 end

--- a/lib/charms/simd.ex
+++ b/lib/charms/simd.ex
@@ -10,11 +10,9 @@ defmodule Charms.SIMD do
   @doc """
   Return the constant value of the given `type` and `literal_values`
   """
-  defintrinsic new(_type, _literal_values), %Opts{
-    args: [type, literal_values],
-    ctx: ctx,
-    block: block
-  } do
+  defintrinsic new(type, literal_values) do
+    %Opts{ctx: ctx, block: block} = __IR__
+
     mlir ctx: ctx, block: block do
       element_type = MLIR.CAPI.mlirShapedTypeGetElementType(type)
 
@@ -41,7 +39,7 @@ defmodule Charms.SIMD do
   @doc """
   Return the vector type of the given `type` and `width`
   """
-  defintrinsic t(_type, _width), %Opts{args: [type, width]} do
+  defintrinsic t(type, width) do
     Type.vector([width], type)
   end
 end

--- a/lib/charms/term.ex
+++ b/lib/charms/term.ex
@@ -8,7 +8,8 @@ defmodule Charms.Term do
   @doc """
   Return the Erlang term type.
   """
-  defintrinsic t(), %Opts{ctx: ctx} do
+  defintrinsic t() do
+    %Opts{ctx: ctx} = __IR__
     Beaver.ENIF.Type.term(ctx: ctx)
   end
 end

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -41,6 +41,7 @@ defmodule AddTwoInt do
 end
 
 defmodule DefmTest do
+  import ExUnit.CaptureIO
   use ExUnit.Case, async: true
 
   test "referenced modules" do
@@ -202,5 +203,19 @@ defmodule DefmTest do
     end
 
     assert TypeOf.foo(2) == 3
+  end
+
+  test "dump" do
+    assert capture_io(fn ->
+             defmodule DumpTerm do
+               use Charms
+               alias Charms.Term
+
+               defm d(env, a) :: Term.t() do
+                 dump(a)
+                 func.return(a)
+               end
+             end
+           end) =~ ~r"block argument.+i64"
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved macro expansion handling with enhanced error messages and type validation.
	- Streamlined intrinsic function definitions by simplifying parameter handling.
	- Introduced a new `dump` function for outputting MLIR entities at compile time.

- **Bug Fixes**
	- Enhanced error reporting for unsupported types and failed expansions.

- **Refactor**
	- Removed pattern matching for options in function signatures, improving readability and maintainability.
	- Centralized context extraction for intrinsic functions.

These changes enhance the clarity, robustness, and usability of the module, ensuring a smoother experience for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->