### PR TITLE
Add `Charms.Constant.from_literal/5`

### DIFF
--- a/lib/charms/constant.ex
+++ b/lib/charms/constant.ex
@@ -1,0 +1,29 @@
+defmodule Charms.Constant do
+  @moduledoc false
+  use Beaver
+  alias Beaver.MLIR.Dialect.{Arith, Index}
+
+  def from_literal(literal, %MLIR.Value{} = v, ctx, blk, loc) do
+    t = MLIR.CAPI.mlirValueGetType(v)
+    from_literal(literal, t, ctx, blk, loc)
+  end
+
+  def from_literal(literal, %MLIR.Type{} = t, ctx, blk, loc) do
+    mlir ctx: ctx, blk: blk do
+      cond do
+        MLIR.Type.integer?(t) ->
+          Arith.constant(value: Attribute.integer(t, literal), loc: loc) >>> t
+
+        MLIR.Type.float?(t) ->
+          Arith.constant(value: Attribute.float(t, literal), loc: loc) >>> t
+
+        MLIR.Type.index?(t) ->
+          Index.constant(value: Attribute.index(literal), loc: loc) >>> t
+
+        true ->
+          loc = Beaver.Deferred.create(loc, ctx)
+          raise CompileError, Charms.Diagnostic.meta_from_loc(loc) ++ [description: "Not a supported type for constant, #{to_string(t)}"]
+      end
+    end
+  end
+end

--- a/lib/charms/defm/definition.ex
+++ b/lib/charms/defm/definition.ex
@@ -298,18 +298,21 @@ defmodule Charms.Defm.Definition do
   """
   def compile(definitions) when is_list(definitions) do
     ctx = MLIR.Context.create()
-    {res, msg} = MLIR.Context.with_diagnostics(
-      ctx,
-      fn ->
-        try do
-          {:ok, do_compile(ctx, definitions)}
-        rescue
-          err ->
-            {:error, err}
-        end
-      end,
-      fn d, _acc -> Charms.Diagnostic.compile_error_message(d) end
-    )
+
+    {res, msg} =
+      MLIR.Context.with_diagnostics(
+        ctx,
+        fn ->
+          try do
+            {:ok, do_compile(ctx, definitions)}
+          rescue
+            err ->
+              {:error, err}
+          end
+        end,
+        fn d, _acc -> Charms.Diagnostic.compile_error_message(d) end
+      )
+
     case {res, msg} do
       {{:ok, {mlir, mods}}, nil} ->
         MLIR.Context.destroy(ctx)

--- a/lib/charms/defm/expander.ex
+++ b/lib/charms/defm/expander.ex
@@ -1210,17 +1210,7 @@ defmodule Charms.Defm.Expander do
     value =
       mlir ctx: state.mlir.ctx, blk: state.mlir.blk do
         loc = MLIR.Location.from_env(env)
-
-        cond do
-          MLIR.CAPI.mlirTypeIsAInteger(type) |> Beaver.Native.to_term() ->
-            Arith.constant(value: Attribute.integer(type, value), loc: loc) >>> type
-
-          MLIR.CAPI.mlirTypeIsAFloat(type) |> Beaver.Native.to_term() ->
-            Arith.constant(value: Attribute.float(type, value), loc: loc) >>> type
-
-          true ->
-            raise_compile_error(env, "Unsupported type for const macro: #{to_string(type)}")
-        end
+        Charms.Constant.from_literal(value, type, state.mlir.ctx, state.mlir.blk, loc)
       end
 
     {value, state, env}

--- a/lib/charms/diagnostic.ex
+++ b/lib/charms/diagnostic.ex
@@ -2,21 +2,21 @@ defmodule Charms.Diagnostic do
   @moduledoc false
   @doc false
   alias Beaver.MLIR
+
+  def meta_from_loc(%MLIR.Location{} = loc) do
+    c = Regex.named_captures(~r/(?<file>.+):(?<line>\d+):(?<column>\d+)/, MLIR.to_string(loc))
+    [file: c["file"], line: c["line"] || 0]
+  end
+
   def compile_error_message(%Beaver.MLIR.Diagnostic{} = d) do
-    loc = to_string(MLIR.location(d))
     txt = to_string(d)
+
     case txt do
       "" ->
         {:error, "No diagnostic message"}
 
       note ->
-        c =
-          Regex.named_captures(
-            ~r/(?<file>.+):(?<line>\d+):(?<column>\d+)/,
-            loc
-          )
-
-        {:ok, [file: c["file"], line: c["line"] || 0, description: note]}
+        {:ok, meta_from_loc(MLIR.location(d)) ++ [description: note]}
     end
   end
 

--- a/test/const_test.exs
+++ b/test/const_test.exs
@@ -16,7 +16,7 @@ defmodule ConstTest do
     end
 
     assert_raise CompileError,
-                 ~r"test/const_test.exs:13: Unsupported type for const macro: tensor<\*xf64>",
+                 ~r"test/const_test.exs:13: Not a supported type for constant, tensor<\*xf64>",
                  f
   end
 end

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -16,6 +16,8 @@ defmodule AddTwoInt do
         a = Pointer.load(i32(), ptr_a)
         b = Pointer.load(i32(), ptr_b)
         sum = value llvm.add(a, b) :: i32()
+        sum = sum / 1
+        sum = sum + 1 - 1
         term = enif_make_int(env, sum)
         func.return(term)
       else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for handling constants in the MLIR context.
	- Added a new method for extracting metadata from MLIR locations.

- **Bug Fixes**
	- Improved error messaging for unsupported types in the `const` macro.

- **Refactor**
	- Simplified constant creation logic in the `expand_macro` function.
	- Updated error handling and control flow in the JIT initialization process.
	- Streamlined handling of binary operations and constants in the Kernel module.

- **Tests**
	- Enhanced clarity of error messages in test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->