### PR TITLE
Rename macro `defintr`

### DIFF
--- a/lib/charms/env.ex
+++ b/lib/charms/env.ex
@@ -5,7 +5,7 @@ defmodule Charms.Env do
   use Charms.Intrinsic
   alias Charms.Intrinsic.Opts
 
-  defintrinsic t() do
+  defintr t() do
     %Opts{ctx: ctx} = __IR__
     Beaver.ENIF.Type.env(ctx: ctx)
   end

--- a/lib/charms/intrinsic.ex
+++ b/lib/charms/intrinsic.ex
@@ -67,7 +67,7 @@ defmodule Charms.Intrinsic do
   @doc """
   To implement an intrinsic function
   """
-  defmacro defintrinsic(call, do: body) do
+  defmacro defintr(call, do: body) do
     {name, _meta, args} = call
     call = recompose_when_clauses(name, args)
     placeholder_args = normalize_arg_names(args)

--- a/lib/charms/kernel.ex
+++ b/lib/charms/kernel.ex
@@ -49,7 +49,7 @@ defmodule Charms.Kernel do
   end
 
   for name <- @binary_ops ++ @binary_macro_ops do
-    defintrinsic unquote(name)(left, right) do
+    defintr unquote(name)(left, right) do
       %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
 
       {operands, type} =
@@ -77,7 +77,7 @@ defmodule Charms.Kernel do
     end
   end
 
-  defintrinsic !value do
+  defintr !value do
     t = MLIR.Value.type(value)
 
     unless MLIR.CAPI.mlirTypeIsAInteger(t) |> Beaver.Native.to_term() do

--- a/lib/charms/pointer.ex
+++ b/lib/charms/pointer.ex
@@ -13,7 +13,7 @@ defmodule Charms.Pointer do
   @doc """
   Allocates a single element of the given `elem_type`, returning a pointer to it.
   """
-  defintrinsic allocate(elem_type) do
+  defintr allocate(elem_type) do
     {quote do
        Charms.Pointer.allocate(elem_type, 1)
      end, elem_type: elem_type}
@@ -22,7 +22,7 @@ defmodule Charms.Pointer do
   @doc """
   Allocates an array of `size` elements of the given `elem_type`, returning a pointer to it.
   """
-  defintrinsic allocate(elem_type, size) do
+  defintr allocate(elem_type, size) do
     %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
 
     mlir ctx: ctx, blk: blk do
@@ -70,7 +70,7 @@ defmodule Charms.Pointer do
   @doc """
   Loads a value of `type` from the given pointer `ptr`.
   """
-  defintrinsic load(type, ptr) do
+  defintr load(type, ptr) do
     %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
 
     if MLIR.equal?(MLIR.Value.type(ptr), ~t{!llvm.ptr}) do
@@ -85,7 +85,7 @@ defmodule Charms.Pointer do
     end
   end
 
-  defintrinsic load(%MLIR.Value{} = ptr) do
+  defintr load(%MLIR.Value{} = ptr) do
     t = MLIR.Value.type(ptr)
 
     if memref_ptr?(t) do
@@ -100,7 +100,7 @@ defmodule Charms.Pointer do
   @doc """
   Stores a value `val` at the given pointer `ptr`.
   """
-  defintrinsic store(val, ptr) do
+  defintr store(val, ptr) do
     %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
 
     mlir ctx: ctx, blk: blk do
@@ -147,7 +147,7 @@ defmodule Charms.Pointer do
     end
   end
 
-  defintrinsic element_ptr(%MLIR.Type{} = elem_type, ptr, n) do
+  defintr element_ptr(%MLIR.Type{} = elem_type, ptr, n) do
     %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
 
     t = MLIR.Value.type(ptr)
@@ -179,7 +179,7 @@ defmodule Charms.Pointer do
   @doc """
   Gets the element pointer of `elem_type` for the given base pointer `ptr` and index `n`.
   """
-  defintrinsic element_ptr(%MLIR.Value{} = ptr, n) do
+  defintr element_ptr(%MLIR.Value{} = ptr, n) do
     t = MLIR.Value.type(ptr)
 
     if memref_ptr?(t) do
@@ -191,7 +191,7 @@ defmodule Charms.Pointer do
     end
   end
 
-  defintrinsic element_type(%MLIR.Value{} = ptr) do
+  defintr element_type(%MLIR.Value{} = ptr) do
     t = MLIR.Value.type(ptr)
 
     if memref_ptr?(t) do
@@ -204,12 +204,12 @@ defmodule Charms.Pointer do
   @doc """
   Return the pointer type
   """
-  defintrinsic t() do
+  defintr t() do
     %Opts{ctx: ctx} = __IR__
     Beaver.Deferred.create(~t{!llvm.ptr}, ctx)
   end
 
-  defintrinsic t(elem_t) do
+  defintr t(elem_t) do
     %Opts{ctx: ctx} = __IR__
     ptr_type(elem_t, ctx)
   end
@@ -252,7 +252,7 @@ defmodule Charms.Pointer do
     end
   end
 
-  defintrinsic copy(source, destination, bytes_count) do
+  defintr copy(source, destination, bytes_count) do
     %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
     source = extract_raw_pointer(source, __IR__)
     destination = extract_raw_pointer(destination, __IR__)

--- a/lib/charms/prelude.ex
+++ b/lib/charms/prelude.ex
@@ -18,7 +18,7 @@ defmodule Charms.Prelude do
     v
   end
 
-  defintrinsic result_at(%MLIR.Operation{} = op, index) do
+  defintr result_at(%MLIR.Operation{} = op, index) do
     num_results = MLIR.CAPI.mlirOperationGetNumResults(op)
 
     if index < num_results do
@@ -32,11 +32,11 @@ defmodule Charms.Prelude do
   @doc """
   Get the MLIR type of the given value.
   """
-  defintrinsic type_of(value) do
+  defintr type_of(value) do
     MLIR.Value.type(value)
   end
 
-  defintrinsic const(ast) do
+  defintr const(ast) do
     {:"::", _type_meta, [value, type]} = ast
     %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
 
@@ -48,7 +48,7 @@ defmodule Charms.Prelude do
   @doc """
   Dump the MLIR entity at compile time with `IO.puts/1`
   """
-  defintrinsic dump(entity) do
+  defintr dump(entity) do
     entity |> tap(&IO.puts(MLIR.to_string(&1)))
   end
 
@@ -98,7 +98,7 @@ defmodule Charms.Prelude do
     arity = Beaver.ENIF.signature(signature_ctx, name) |> elem(0) |> length()
     args = Macro.generate_arguments(arity, __MODULE__)
 
-    defintrinsic unquote(name)(unquote_splicing(args)) do
+    defintr unquote(name)(unquote_splicing(args)) do
       call_enif(unquote(name), unquote(args), __IR__)
     end
   end

--- a/lib/charms/simd.ex
+++ b/lib/charms/simd.ex
@@ -10,7 +10,7 @@ defmodule Charms.SIMD do
   @doc """
   Return the constant value of the given `type` and `literal_values`
   """
-  defintrinsic new(type, literal_values) do
+  defintr new(type, literal_values) do
     %Opts{ctx: ctx, blk: blk} = __IR__
 
     mlir ctx: ctx, blk: blk do
@@ -39,7 +39,7 @@ defmodule Charms.SIMD do
   @doc """
   Return the vector type of the given `type` and `width`
   """
-  defintrinsic t(type, width) do
+  defintr t(type, width) do
     Type.vector([width], type)
   end
 end

--- a/lib/charms/term.ex
+++ b/lib/charms/term.ex
@@ -8,7 +8,7 @@ defmodule Charms.Term do
   @doc """
   Return the Erlang term type.
   """
-  defintrinsic t() do
+  defintr t() do
     %Opts{ctx: ctx} = __IR__
     Beaver.ENIF.Type.term(ctx: ctx)
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `defintrinsic` macro to `defintr` across multiple modules including `Charms.Env`, `Charms.Intrinsic`, `Charms.Kernel`, `Charms.Pointer`, `Charms.Prelude`, `Charms.SIMD`, and `Charms.Term`
	- Updated function definitions to use the new `defintr` keyword while maintaining existing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->