### PR TITLE
`ptr!/1` and `ptr!/2` as syntax sugar

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -7,6 +7,8 @@ locals_without_parens = [
   defm: 2,
   defbind: 1,
   set!: 2,
+  ptr!: 1,
+  ptr!: 2,
   defmstruct: 1
 ]
 

--- a/bench/enif_merge_sort.ex
+++ b/bench/enif_merge_sort.ex
@@ -15,13 +15,13 @@ defmodule ENIFMergeSort do
 
   @err %ArgumentError{message: "list expected"}
   defm sort(env, list) :: Term.t() do
-    len_ptr = Pointer.allocate(i32())
+    len_ptr = ptr! i32()
 
     if enif_get_list_length(env, list, len_ptr) != 0 do
-      movable_list_ptr = Pointer.allocate(Term.t())
+      movable_list_ptr = ptr! Term.t()
       set! movable_list_ptr[0], list
       len = len_ptr[0]
-      arr = Pointer.allocate(Term.t(), len)
+      arr = ptr! Term.t(), len
       SortUtil.copy_terms(env, movable_list_ptr, arr)
       zero = const 0 :: i32()
       do_sort(arr, zero, len - 1)

--- a/bench/enif_quick_sort.ex
+++ b/bench/enif_quick_sort.ex
@@ -12,7 +12,7 @@ defmodule ENIFQuickSort do
 
   defm partition(arr :: Pointer.t(Term.t()), low :: i32(), high :: i32()) :: i32() do
     pivot = arr[high]
-    i_ptr = Pointer.allocate(i32())
+    i_ptr = ptr! i32()
     set! i_ptr[0], low - 1
     start = arr + low
 
@@ -39,13 +39,13 @@ defmodule ENIFQuickSort do
 
   @err %ArgumentError{message: "list expected"}
   defm sort(env, list) :: Term.t() do
-    len_ptr = Pointer.allocate(i32())
+    len_ptr = ptr! i32()
 
     if enif_get_list_length(env, list, len_ptr) != 0 do
-      movable_list_ptr = Pointer.allocate(Term.t())
+      movable_list_ptr = ptr! Term.t()
       set! movable_list_ptr[0], list
       len = len_ptr[0]
-      arr = Pointer.allocate(Term.t(), len)
+      arr = ptr! Term.t(), len
       SortUtil.copy_terms(env, movable_list_ptr, arr)
       zero = const 0 :: i32()
       do_sort(arr, zero, len - 1)

--- a/bench/enif_tim_sort.ex
+++ b/bench/enif_tim_sort.ex
@@ -11,7 +11,7 @@ defmodule ENIFTimSort do
     for_loop {temp, i} <- {start, n} do
       i = value index.casts(i) :: i32()
       i = i + start_i
-      j_ptr = Pointer.allocate(i32())
+      j_ptr = ptr! i32()
       set! j_ptr[0], i - 1
 
       while(j_ptr[0] >= left && arr[j_ptr[0]] > temp) do
@@ -27,7 +27,7 @@ defmodule ENIFTimSort do
 
   defm tim_sort(arr :: Pointer.t(Term.t()), n :: i32()) do
     run = const 32 :: i32()
-    i_ptr = Pointer.allocate(i32())
+    i_ptr = ptr! i32()
     zero = const 0 :: i32()
     set! i_ptr[0], zero
 
@@ -38,13 +38,13 @@ defmodule ENIFTimSort do
       set! i_ptr[0], i + run
     end
 
-    size_ptr = Pointer.allocate(i32())
+    size_ptr = ptr! i32()
     set! size_ptr[0], run
 
     while size_ptr[0] < n do
       size = size_ptr[0]
 
-      left_ptr = Pointer.allocate(i32())
+      left_ptr = ptr! i32()
       set! left_ptr[0], zero
 
       while left_ptr[0] < n do
@@ -66,13 +66,13 @@ defmodule ENIFTimSort do
 
   @err %ArgumentError{message: "list expected"}
   defm sort(env, list) :: Term.t() do
-    len_ptr = Pointer.allocate(i32())
+    len_ptr = ptr! i32()
 
     if enif_get_list_length(env, list, len_ptr) != 0 do
-      movable_list_ptr = Pointer.allocate(Term.t())
+      movable_list_ptr = ptr! Term.t()
       set! movable_list_ptr[0], list
       len = len_ptr[0]
-      arr = Pointer.allocate(Term.t(), len)
+      arr = ptr! Term.t(), len
       SortUtil.copy_terms(env, movable_list_ptr, arr)
       tim_sort(arr, len)
       enif_make_list_from_array(env, arr, len)

--- a/bench/sort_util.ex
+++ b/bench/sort_util.ex
@@ -4,9 +4,9 @@ defmodule SortUtil do
   alias Charms.{Pointer, Term}
 
   defm copy_terms(env, movable_list_ptr :: Pointer.t(Term.t()), arr :: Pointer.t(Term.t())) do
-    head = Pointer.allocate(Term.t())
+    head = ptr! Term.t()
     zero = const 0 :: i32()
-    i_ptr = Pointer.allocate(i32())
+    i_ptr = ptr! i32()
     set! i_ptr[0], zero
 
     while(
@@ -28,8 +28,8 @@ defmodule SortUtil do
     n1 = m - l + 1
     n2 = r - m
 
-    left_temp = Pointer.allocate(Term.t(), n1)
-    right_temp = Pointer.allocate(Term.t(), n2)
+    left_temp = ptr! Term.t(), n1
+    right_temp = ptr! Term.t(), n2
 
     for_loop {element, i} <- {arr + l, n1} do
       set! left_temp[i], element
@@ -39,9 +39,9 @@ defmodule SortUtil do
       set! right_temp[j], element
     end
 
-    i_ptr = Pointer.allocate(i32())
-    j_ptr = Pointer.allocate(i32())
-    k_ptr = Pointer.allocate(i32())
+    i_ptr = ptr! i32()
+    j_ptr = ptr! i32()
+    k_ptr = ptr! i32()
 
     zero = const 0 :: i32()
     set! i_ptr[0], zero

--- a/bench/vec_add_int_list.ex
+++ b/bench/vec_add_int_list.ex
@@ -4,13 +4,13 @@ defmodule AddTwoIntVec do
   alias Charms.{SIMD, Term, Pointer}
 
   defm load_list(env, l :: Term.t()) :: SIMD.t(i32(), 8) do
-    i_ptr = Pointer.allocate(i32())
+    i_ptr = ptr! i32()
     zero = const 0 :: Pointer.element_type(i_ptr)
     set! i_ptr[0], zero
     init = SIMD.new(SIMD.t(i32(), 8), [0, 0, 0, 0, 0, 0, 0, 0])
 
     Enum.reduce(l, init, fn x, acc ->
-      v_ptr = Pointer.allocate(i32())
+      v_ptr = ptr! i32()
       enif_get_int(env, x, v_ptr)
       i = i_ptr[0]
       set! i_ptr[0], i + 1

--- a/lib/charms/prelude.ex
+++ b/lib/charms/prelude.ex
@@ -53,7 +53,7 @@ defmodule Charms.Prelude do
   end
 
   @doc """
-  Syntactic sugar for `Charms.Pointer.allocate/1` to print the MLIR entity at compile time.
+  Syntactic sugar for `Charms.Pointer.allocate/1`.
   """
   defintr ptr!(t) do
     {
@@ -65,7 +65,7 @@ defmodule Charms.Prelude do
   end
 
   @doc """
-  Syntactic sugar for `Charms.Pointer.allocate/2` to print the MLIR entity at compile time.
+  Syntactic sugar for `Charms.Pointer.allocate/2`.
   """
   defintr ptr!(t, n) do
     {

--- a/test/add_two_int_test.exs
+++ b/test/add_two_int_test.exs
@@ -4,11 +4,11 @@ defmodule AddTwoIntTest do
   test "add two integers" do
     defmodule AddTwoInt do
       use Charms, init: false
-      alias Charms.{Pointer, Term}
+      alias Charms.Term
 
       defm add_or_error_with_cond_br(env, a, b, error) :: Term.t() do
-        ptr_a = Pointer.allocate(i32())
-        ptr_b = Pointer.allocate(i32())
+        ptr_a = ptr! i32()
+        ptr_b = ptr! i32()
 
         arg_err =
           block do
@@ -33,8 +33,8 @@ defmodule AddTwoIntTest do
       end
 
       defm add(env, a, b) :: Term.t() do
-        ptr_a = Pointer.allocate(i32())
-        ptr_b = Pointer.allocate(i32())
+        ptr_a = ptr! i32()
+        ptr_b = ptr! i32()
 
         if !enif_get_int(env, a, ptr_a) || !enif_get_int(env, b, ptr_b) do
           enif_make_badarg(env)

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -140,7 +140,7 @@ defmodule DefmTest do
 
       defm foo(env, a) :: Term.t() do
         b = const 1 :: i32()
-        i_ptr = Pointer.allocate(type_of(b))
+        i_ptr = ptr! type_of(b)
         enif_get_int(env, a, i_ptr)
         sum = Pointer.load(type_of(b), i_ptr) + b
         enif_make_int(env, sum)
@@ -182,12 +182,11 @@ defmodule DefmTest do
     defmodule ArrayIndexing do
       use Charms
       alias Charms.Term
-      alias Charms.Pointer
 
       defm foo(env) :: Term.t() do
-        dst_arr = Pointer.allocate(f64(), 2)
+        dst_arr = ptr! f64(), 2
         val = const 1.1 :: f64()
-        src_arr = Pointer.allocate(f64())
+        src_arr = ptr! f64()
         set! src_arr[0], val
         set! dst_arr[1], src_arr[0]
         enif_make_double(env, dst_arr[1])

--- a/test/if_test.exs
+++ b/test/if_test.exs
@@ -4,12 +4,12 @@ defmodule IfTest do
   test "if with value" do
     defmodule GetIntIf do
       use Charms
-      alias Charms.{Pointer, Term}
+      alias Charms.Term
 
       defm get(env, i) :: Term.t() do
         zero = const 0 :: i32()
         one = const 1 :: i32()
-        i_ptr = Pointer.allocate(i32())
+        i_ptr = ptr! i32()
         enif_get_int(env, i, i_ptr)
         i = i_ptr[0]
 

--- a/test/support/sqrt.ex
+++ b/test/support/sqrt.ex
@@ -2,12 +2,12 @@ defmodule SqrtWrapper do
   @moduledoc false
   require Logger
   use Charms
-  alias Charms.{Term, Pointer}
+  alias Charms.Term
 
   defbind sqrt_c(x :: f64()) :: f64()
 
   defm sqrt(env, x :: Term.t()) :: Term.t() do
-    f_ptr = Pointer.allocate(f64())
+    f_ptr = ptr! f64()
     enif_get_double(env, x, f_ptr)
     f = f_ptr[0]
     r = sqrt_c(f)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated pointer allocation syntax throughout the codebase to use a more concise and consistent format.
- **Documentation**
	- Clarified documentation for pointer allocation macros, removing outdated references.
- **Tests**
	- Updated test files to use the new pointer allocation syntax for improved readability.
- **Chores**
	- Adjusted formatting configuration to support the new pointer allocation syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->