### PR TITLE
Zig-like `defer` macro

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -9,6 +9,8 @@ locals_without_parens = [
   set!: 2,
   ptr!: 1,
   ptr!: 2,
+  defer: 1,
+  free!: 1,
   defmstruct: 1
 ]
 

--- a/bench/enif_tim_sort.ex
+++ b/bench/enif_tim_sort.ex
@@ -75,6 +75,7 @@ defmodule ENIFTimSort do
       arr = ptr! Term.t(), len
       SortUtil.copy_terms(env, movable_list_ptr, arr)
       tim_sort(arr, len)
+      defer free! arr
       enif_make_list_from_array(env, arr, len)
     else
       enif_raise_exception(env, @err)

--- a/lib/charms/defm.ex
+++ b/lib/charms/defm.ex
@@ -51,6 +51,11 @@ defmodule Charms.Defm do
   """
   defmacro set!(_index_expression, _value), do: :implemented_in_expander
 
+  @doc """
+  Executes an expression unconditionally at do-block exit.
+  """
+  defmacro defer(_expression), do: :implemented_in_expander
+
   @doc false
   def mangling(mod, func) do
     Module.concat(mod, func) |> to_string() |> String.replace(".", "$")

--- a/lib/charms/defm/definition.ex
+++ b/lib/charms/defm/definition.ex
@@ -208,7 +208,8 @@ defmodule Charms.Defm.Definition do
          [b] <- Beaver.Walker.blocks(r) |> Enum.to_list(),
          last_op = %MLIR.Operation{} <-
            Beaver.Walker.operations(b) |> Enum.to_list() |> List.last(),
-         false <- MLIR.Operation.name(last_op) == "func.return" do
+         last_op_name <- MLIR.Operation.name(last_op),
+         false <- last_op_name == "func.return" do
       case func[:function_type]
            |> MLIR.Attribute.unwrap()
            |> MLIR.CAPI.mlirFunctionTypeGetNumResults()
@@ -219,7 +220,8 @@ defmodule Charms.Defm.Definition do
           end
 
         1 ->
-          raise ArgumentError, "Expected func.return returns a single value"
+          raise ArgumentError,
+                "Expected func.return returns a single value, instead we got #{last_op_name}"
 
         _ ->
           raise ArgumentError, "Multiple return values are not supported yet."

--- a/lib/charms/defm/expander.ex
+++ b/lib/charms/defm/expander.ex
@@ -624,6 +624,8 @@ defmodule Charms.Defm.Expander do
   end
 
   defp expand_deferrals(state) do
+    # each defer statement's environment should not inferrer with each other
+    # this discourage using binding expression in one-line defer, but it is supported in defer-block
     for {expression, state, env} <- state.mlir.deferrals do
       expand(expression, state, env)
     end

--- a/lib/charms/defm/pass/use_enif_alloc.ex
+++ b/lib/charms/defm/pass/use_enif_alloc.ex
@@ -1,0 +1,64 @@
+defmodule Charms.Defm.Pass.UseENIFAlloc do
+  @moduledoc false
+  use Beaver
+  use MLIR.Pass, on: "builtin.module"
+  alias MLIR.Dialect.LLVM
+  import Beaver.Pattern
+
+  def initialize(ctx, nil) do
+    patterns = [
+      replace_alloc(),
+      replace_free()
+    ]
+
+    frozen_pat_set = Beaver.Pattern.compile_patterns(ctx, patterns)
+    {:ok, %{patterns: frozen_pat_set}}
+  end
+
+  def destruct(nil) do
+    :ok
+  end
+
+  def destruct(%{patterns: frozen_pat_set}) do
+    MLIR.CAPI.mlirFrozenRewritePatternSetDestroy(frozen_pat_set)
+  end
+
+  defpat replace_alloc(benefit: 10) do
+    size = value()
+    ptr_t = type()
+    {op, _} = LLVM.call(size, callee: Attribute.flat_symbol_ref("malloc")) >>> {:op, [ptr_t]}
+
+    rewrite op do
+      r =
+        LLVM.call(size,
+          callee: Attribute.flat_symbol_ref("enif_alloc"),
+          operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([1, 0]),
+          op_bundle_sizes: ~a{array<i32>}
+        ) >>> ptr_t
+
+      replace(op, with: r)
+    end
+  end
+
+  defpat replace_free(benefit: 10) do
+    ptr = value()
+    {op, _} = LLVM.call(ptr, callee: Attribute.flat_symbol_ref("free")) >>> {:op, []}
+
+    rewrite op do
+      {enif_free, _} =
+        LLVM.call(ptr,
+          callee: Attribute.flat_symbol_ref("enif_free"),
+          operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([1, 0]),
+          op_bundle_sizes: ~a{array<i32>}
+        ) >>> {:op, []}
+
+      replace(op, with: enif_free)
+    end
+  end
+
+  def run(op, %{patterns: patterns} = state) do
+    module = MLIR.Module.from_operation(op)
+    MLIR.apply!(module, patterns)
+    state
+  end
+end

--- a/lib/charms/pointer.ex
+++ b/lib/charms/pointer.ex
@@ -264,4 +264,23 @@ defmodule Charms.Pointer do
       ) >>> []
     end
   end
+
+  @doc """
+  Frees memory previously allocated with allocate/1 or allocate/2.
+  """
+  defintr free(ptr) do
+    %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
+
+    t = MLIR.Value.type(ptr)
+
+    if MLIR.Type.llvm_pointer?(t) do
+      mlir ctx: ctx, blk: blk do
+        raise ArgumentError, "Cannot free LLVM pointers"
+      end
+    else
+      mlir ctx: ctx, blk: blk do
+        MemRef.dealloc(ptr, loc: loc) >>> []
+      end
+    end
+  end
 end

--- a/lib/charms/pointer.ex
+++ b/lib/charms/pointer.ex
@@ -283,4 +283,15 @@ defmodule Charms.Pointer do
       end
     end
   end
+
+  @doc """
+  Get a null raw ptr
+  """
+  defintr null() do
+    %Opts{ctx: ctx, blk: blk, loc: loc} = __IR__
+
+    mlir ctx: ctx, blk: blk do
+      LLVM.mlir_zero(loc: loc) >>> ~t{!llvm.ptr}
+    end
+  end
 end

--- a/lib/charms/pointer.ex
+++ b/lib/charms/pointer.ex
@@ -27,19 +27,16 @@ defmodule Charms.Pointer do
 
     mlir ctx: ctx, blk: blk do
       zero = Index.constant(value: Attribute.index(0)) >>> Type.index()
+      operand_segment_sizes_of_zeros = Beaver.MLIR.ODS.operand_segment_sizes([0, 0])
 
       case size do
         1 ->
-          MemRef.alloca(
-            loc: loc,
-            operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([0, 0])
-          ) >>> Type.memref!([1], elem_type)
+          MemRef.alloca(loc: loc, operand_segment_sizes: operand_segment_sizes_of_zeros) >>>
+            Type.memref!([1], elem_type)
 
         i when is_integer(i) ->
-          MemRef.alloc(
-            loc: loc,
-            operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([0, 0])
-          ) >>> Type.memref!([i], elem_type)
+          MemRef.alloc(loc: loc, operand_segment_sizes: operand_segment_sizes_of_zeros) >>>
+            Type.memref!([i], elem_type)
 
         %MLIR.Value{} ->
           size =
@@ -49,10 +46,8 @@ defmodule Charms.Pointer do
               Index.casts(size, loc: loc) >>> Type.index()
             end
 
-          MemRef.alloc(size,
-            loc: loc,
-            operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([1, 0])
-          ) >>> Type.memref!([:dynamic], elem_type)
+          MemRef.alloc(dynamicSizes: size, loc: loc, operand_segment_sizes: :infer) >>>
+            Type.memref!([:dynamic], elem_type)
       end
       |> offset_ptr(elem_type, zero, ctx, blk, loc)
     end
@@ -135,8 +130,11 @@ defmodule Charms.Pointer do
 
       offset = Arith.addi(offset_extracted, offset, loc: loc) >>> Type.index()
 
-      MemRef.reinterpret_cast(ptr, offset, size,
-        operand_segment_sizes: Beaver.MLIR.ODS.operand_segment_sizes([1, 1, 1, 0]),
+      MemRef.reinterpret_cast(
+        source: ptr,
+        offsets: offset,
+        sizes: size,
+        operand_segment_sizes: :infer,
         static_offsets: static_offsets_or_sizes,
         static_sizes: static_offsets_or_sizes,
         static_strides: static_strides,

--- a/lib/charms/prelude.ex
+++ b/lib/charms/prelude.ex
@@ -149,7 +149,7 @@ defmodule Charms.Prelude do
       call_enif(unquote(name), unquote(args), __IR__)
     end
 
-    if Atom.to_string(name) |> String.starts_with?("enif_get_") do
+    if String.starts_with?(Atom.to_string(name), "enif_get_") or name == :enif_send do
       defintr unquote(String.to_atom("#{name}!"))(unquote_splicing(args)) do
         {
           quote do

--- a/lib/charms/term.ex
+++ b/lib/charms/term.ex
@@ -12,4 +12,36 @@ defmodule Charms.Term do
     %Opts{ctx: ctx} = __IR__
     Beaver.ENIF.Type.term(ctx: ctx)
   end
+
+  defintr to_i32!(env, term) do
+    {quote do
+       ptr = ptr! i32()
+       enif_get_int!(env, term, ptr)
+       ptr[0]
+     end, env: env, term: term}
+  end
+
+  defintr to_i64!(env, term) do
+    {quote do
+       ptr = ptr! i64()
+       enif_get_int64!(env, term, ptr)
+       ptr[0]
+     end, env: env, term: term}
+  end
+
+  defintr to_f64!(env, term) do
+    {quote do
+       ptr = ptr! f64()
+       enif_get_double!(env, term, ptr)
+       ptr[0]
+     end, env: env, term: term}
+  end
+
+  defintr to_pid!(env, term) do
+    {quote do
+       ptr = ptr! i64()
+       enif_get_local_pid!(env, term, ptr)
+       ptr
+     end, env: env, term: term}
+  end
 end

--- a/test/defer_test.exs
+++ b/test/defer_test.exs
@@ -1,0 +1,57 @@
+defmodule DeferTest do
+  use ExUnit.Case, async: true
+
+  defmodule DeferSendMessage do
+    use Charms
+    alias Charms.Term
+
+    @ok :ok
+    defm test_defer_with_message(env, pid_term, msg1, msg2, msg3) :: Term.t() do
+      pid = Term.to_pid!(env, pid_term)
+      null_env = enif_alloc_env()
+      defer enif_send(env, pid, null_env, msg3)
+      defer enif_send(env, pid, null_env, msg2)
+      enif_send(env, pid, null_env, msg1)
+      @ok
+    end
+
+    defm test_defer_with_explicit_terminator(env, pid_term, msg) :: Term.t() do
+      pid = Term.to_pid!(env, pid_term)
+      defer enif_send(env, pid, enif_alloc_env(), msg)
+      func.return(@ok)
+    end
+
+    defm test_defer_with_do_block(env, pid_term, msg1, msg2, msg3) :: Term.t() do
+      pid = Term.to_pid!(env, pid_term)
+
+      defer do
+        enif_send(env, pid, enif_alloc_env(), msg1)
+        enif_send(env, pid, enif_alloc_env(), msg2)
+        enif_send(env, pid, enif_alloc_env(), msg3)
+      end
+
+      func.return(@ok)
+    end
+  end
+
+  @messages [test: 1, test: 2, test: 3]
+  test "order of defer send message" do
+    pid = self()
+    [msg1, msg2, msg3] = @messages
+    assert :ok = DeferSendMessage.test_defer_with_message(pid, msg1, msg2, msg3)
+    assert {:messages, @messages} = Process.info(pid, :messages)
+  end
+
+  test "defer with explicit terminator" do
+    msg = :test
+    assert :ok = DeferSendMessage.test_defer_with_explicit_terminator(self(), msg)
+    assert_receive ^msg
+  end
+
+  test "defer with do-block" do
+    pid = self()
+    [msg1, msg2, msg3] = @messages
+    assert :ok = DeferSendMessage.test_defer_with_do_block(pid, msg1, msg2, msg3)
+    assert {:messages, @messages} = Process.info(pid, :messages)
+  end
+end

--- a/test/defer_test.exs
+++ b/test/defer_test.exs
@@ -3,21 +3,22 @@ defmodule DeferTest do
 
   defmodule DeferSendMessage do
     use Charms
-    alias Charms.Term
+    alias Charms.{Term, Pointer}
 
     @ok :ok
     defm test_defer_with_message(env, pid_term, msg1, msg2, msg3) :: Term.t() do
       pid = Term.to_pid!(env, pid_term)
-      null_env = enif_alloc_env()
-      defer enif_send(env, pid, null_env, msg3)
-      defer enif_send(env, pid, null_env, msg2)
-      enif_send(env, pid, null_env, msg1)
+      null_env = Pointer.null()
+      defer enif_send!(env, pid, null_env, msg3)
+      defer enif_send!(env, pid, null_env, msg2)
+      enif_send!(env, pid, null_env, msg1)
       @ok
     end
 
     defm test_defer_with_explicit_terminator(env, pid_term, msg) :: Term.t() do
       pid = Term.to_pid!(env, pid_term)
-      defer enif_send(env, pid, enif_alloc_env(), msg)
+      null_env = Pointer.null()
+      defer enif_send!(env, pid, Pointer.null(), msg)
       func.return(@ok)
     end
 
@@ -25,9 +26,10 @@ defmodule DeferTest do
       pid = Term.to_pid!(env, pid_term)
 
       defer do
-        enif_send(env, pid, enif_alloc_env(), msg1)
-        enif_send(env, pid, enif_alloc_env(), msg2)
-        enif_send(env, pid, enif_alloc_env(), msg3)
+        null_env = Pointer.null()
+        enif_send!(env, pid, null_env, msg1)
+        enif_send!(env, pid, null_env, msg2)
+        enif_send!(env, pid, null_env, msg3)
       end
 
       func.return(@ok)

--- a/test/defm_test.exs
+++ b/test/defm_test.exs
@@ -198,7 +198,7 @@ defmodule DefmTest do
       defm foo(env, a) :: Term.t() do
         b = const 1 :: i32()
         i_ptr = ptr! type_of(b)
-        enif_get_int(env, a, i_ptr)
+        if enif_get_int(env, a, i_ptr) == 0, do: unreachable!()
         sum = Pointer.load(type_of(b), i_ptr) + b
         enif_make_int(env, sum)
       end
@@ -284,8 +284,14 @@ defmodule DefmTest do
           size2 = const 2 :: i64()
           size1 = const 1 :: index()
           dst_arr = ptr! f64(), size2
-          val = const 1.1 :: f64()
           src_arr = ptr! f64(), size1
+
+          defer do
+            free! dst_arr
+            free! src_arr
+          end
+
+          val = const 1.1 :: f64()
           set! src_arr[0], val
           set! dst_arr[1], src_arr[0]
           enif_make_double(env, dst_arr[1])

--- a/test/if_test.exs
+++ b/test/if_test.exs
@@ -10,7 +10,7 @@ defmodule IfTest do
         zero = const 0 :: i32()
         one = const 1 :: i32()
         i_ptr = ptr! i32()
-        enif_get_int(env, i, i_ptr)
+        if enif_get_int(env, i, i_ptr) == 0, do: unreachable!()
         i = i_ptr[0]
 
         ret =

--- a/test/support/kernel_binary.ex
+++ b/test/support/kernel_binary.ex
@@ -5,86 +5,56 @@ defmodule KernelBinary do
 
   # Integer operations
   defm add_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int + b_int
     enif_make_int(env, c)
   end
 
   defm sub_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int - b_int
     enif_make_int(env, c)
   end
 
   defm mul_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int * b_int
     enif_make_int(env, c)
   end
 
   defm div_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int / b_int
     enif_make_int(env, c)
   end
 
   defm and_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int && b_int
     enif_make_int(env, c)
   end
 
   defm or_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int || b_int
     enif_make_int(env, c)
   end
 
   defm not_int(env, a :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    a_int = a_ptr[0]
+    a_int = Term.to_i32!(env, a)
     c = !a_int
     enif_make_int(env, c)
   end
 
   defm eq_int(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! i32()
-    b_ptr = ptr! i32()
-    enif_get_int(env, a, a_ptr)
-    enif_get_int(env, b, b_ptr)
-    a_int = a_ptr[0]
-    b_int = b_ptr[0]
+    a_int = Term.to_i32!(env, a)
+    b_int = Term.to_i32!(env, b)
     c = a_int == b_int
     # Convert boolean to integer for return
     c_i32 = value arith.extui(c) :: i32()
@@ -93,56 +63,36 @@ defmodule KernelBinary do
 
   # Float operations
   defm add_float(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! f64()
-    b_ptr = ptr! f64()
-    enif_get_double(env, a, a_ptr)
-    enif_get_double(env, b, b_ptr)
-    a_float = a_ptr[0]
-    b_float = b_ptr[0]
+    a_float = Term.to_f64!(env, a)
+    b_float = Term.to_f64!(env, b)
     c = a_float + b_float
     enif_make_double(env, c)
   end
 
   defm sub_float(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! f64()
-    b_ptr = ptr! f64()
-    enif_get_double(env, a, a_ptr)
-    enif_get_double(env, b, b_ptr)
-    a_float = a_ptr[0]
-    b_float = b_ptr[0]
+    a_float = Term.to_f64!(env, a)
+    b_float = Term.to_f64!(env, b)
     c = a_float - b_float
     enif_make_double(env, c)
   end
 
   defm mul_float(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! f64()
-    b_ptr = ptr! f64()
-    enif_get_double(env, a, a_ptr)
-    enif_get_double(env, b, b_ptr)
-    a_float = a_ptr[0]
-    b_float = b_ptr[0]
+    a_float = Term.to_f64!(env, a)
+    b_float = Term.to_f64!(env, b)
     c = a_float * b_float
     enif_make_double(env, c)
   end
 
   defm div_float(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! f64()
-    b_ptr = ptr! f64()
-    enif_get_double(env, a, a_ptr)
-    enif_get_double(env, b, b_ptr)
-    a_float = a_ptr[0]
-    b_float = b_ptr[0]
+    a_float = Term.to_f64!(env, a)
+    b_float = Term.to_f64!(env, b)
     c = a_float / b_float
     enif_make_double(env, c)
   end
 
   defm eq_float(env, a :: Term.t(), b :: Term.t()) :: Term.t() do
-    a_ptr = ptr! f64()
-    b_ptr = ptr! f64()
-    enif_get_double(env, a, a_ptr)
-    enif_get_double(env, b, b_ptr)
-    a_float = a_ptr[0]
-    b_float = b_ptr[0]
+    a_float = Term.to_f64!(env, a)
+    b_float = Term.to_f64!(env, b)
     c = a_float == b_float
     # Convert boolean to integer for return
     c_i32 = value arith.extui(c) :: i32()

--- a/test/support/sqrt.ex
+++ b/test/support/sqrt.ex
@@ -7,9 +7,7 @@ defmodule SqrtWrapper do
   defbind sqrt_c(x :: f64()) :: f64()
 
   defm sqrt(env, x :: Term.t()) :: Term.t() do
-    f_ptr = ptr! f64()
-    enif_get_double(env, x, f_ptr)
-    f = f_ptr[0]
+    f = Term.to_f64!(env, x)
     r = sqrt_c(f)
     enif_make_double(env, r)
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Defer semantics to run expressions at block/terminator exit for predictable cleanup.
  - Added free/1 and free! helpers with safeguards for incompatible pointers.
  - Added unreachable! and bang (!) ENIF getter variants to fail-fast on errors.
  - New Term conversions: to_i32!/to_i64!/to_f64!/to_pid! for simpler argument parsing.
  - JIT now uses ENIF allocator during lowering for improved memory handling.

- Tests
  - New tests validating defer ordering, terminator behavior, and updated argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->